### PR TITLE
Commentout with NAT Gateway

### DIFF
--- a/aws/ecs_service.tf
+++ b/aws/ecs_service.tf
@@ -2,17 +2,21 @@ resource "aws_ecs_service" "igsr5_time_management_slack" {
   name             = "igsr5_time_management_slack"
   cluster          = aws_ecs_cluster.igsr5.arn
   task_definition  = aws_ecs_task_definition.igsr5_time_management_slack.arn
-  desired_count    = 2
+  desired_count    = 1
   launch_type      = "FARGATE"
   platform_version = "1.4.0"
   // health_check_grace_period_seconds = 600
 
   network_configuration {
-    assign_public_ip = false
+    assign_public_ip = true
     security_groups  = [module.time_management_slack_sg.security_group_id]
+    // subnets = [
+    //   aws_subnet.igsr5_private_0.id,
+    //   aws_subnet.igsr5_private_1.id,
+    // ]
     subnets = [
-      aws_subnet.igsr5_private_0.id,
-      aws_subnet.igsr5_private_1.id,
+      aws_subnet.igsr5_public_0.id,
+      aws_subnet.igsr5_public_1.id,
     ]
   }
 

--- a/aws/eip.tf
+++ b/aws/eip.tf
@@ -1,4 +1,4 @@
-resource "aws_eip" "nat_gateway" {
-  vpc        = true
-  depends_on = [aws_internet_gateway.igsr5]
-}
+// resource "aws_eip" "nat_gateway" {
+//   vpc        = true
+//   depends_on = [aws_internet_gateway.igsr5]
+// }

--- a/aws/route.tf
+++ b/aws/route.tf
@@ -4,8 +4,8 @@ resource "aws_route" "igsr5_public" {
   destination_cidr_block = "0.0.0.0/0"
 }
 
-resource "aws_route" "igsr5_private" {
-  route_table_id         = aws_route_table.igsr5_private.id
-  nat_gateway_id         = aws_nat_gateway.igsr5.id
-  destination_cidr_block = "0.0.0.0/0"
-}
+// resource "aws_route" "igsr5_private" {
+//   route_table_id         = aws_route_table.igsr5_private.id
+//   nat_gateway_id         = aws_nat_gateway.igsr5.id
+//   destination_cidr_block = "0.0.0.0/0"
+// }

--- a/aws/security_group.tf
+++ b/aws/security_group.tf
@@ -53,11 +53,3 @@ module "igsr5_debug_server_sg_80" {
   port        = 80
   cidr_blocks = ["0.0.0.0/0"]
 }
-
-module "igsr5_sandbox_muson_sg" {
-  source      = "./modules/security_group"
-  name        = "igsr5-sandbox-muson-efs-sg"
-  vpc_id      = aws_vpc.igsr5.id
-  port        = 2049
-  cidr_blocks = [aws_vpc.igsr5.cidr_block]
-}

--- a/aws/security_group.tf
+++ b/aws/security_group.tf
@@ -53,3 +53,11 @@ module "igsr5_debug_server_sg_80" {
   port        = 80
   cidr_blocks = ["0.0.0.0/0"]
 }
+
+module "igsr5_sandbox_muson_sg" {
+  source      = "./modules/security_group"
+  name        = "igsr5-sandbox-muson-efs-sg"
+  vpc_id      = aws_vpc.igsr5.id
+  port        = 2049
+  cidr_blocks = [aws_vpc.igsr5.cidr_block]
+}

--- a/aws/vpc.tf
+++ b/aws/vpc.tf
@@ -75,12 +75,12 @@ resource "aws_internet_gateway" "igsr5" {
 /*
  * nat gateway
  * */
-resource "aws_nat_gateway" "igsr5" {
-  allocation_id = aws_eip.nat_gateway.id
-  subnet_id     = aws_subnet.igsr5_public_0.id
-  depends_on    = [aws_internet_gateway.igsr5]
-
-  tags = {
-    Name = "igsr5"
-  }
-}
+// resource "aws_nat_gateway" "igsr5" {
+//   allocation_id = aws_eip.nat_gateway.id
+//   subnet_id     = aws_subnet.igsr5_public_0.id
+//   depends_on    = [aws_internet_gateway.igsr5]
+// 
+//   tags = {
+//     Name = "igsr5"
+//   }
+// }

--- a/aws/vpc_endpoint.tf
+++ b/aws/vpc_endpoint.tf
@@ -1,23 +1,23 @@
-resource "aws_vpc_endpoint" "s3" {
-  vpc_id            = aws_vpc.igsr5.id
-  service_name      = "com.amazonaws.ap-northeast-1.s3"
-  vpc_endpoint_type = "Gateway"
-}
-
-resource "aws_vpc_endpoint" "ecr_dkr" {
-  vpc_id              = aws_vpc.igsr5.id
-  service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = [aws_subnet.igsr5_private_0.id, aws_subnet.igsr5_private_1.id]
-  security_group_ids  = [module.vpc_endpoint_sg.security_group_id]
-  private_dns_enabled = true
-}
-
-resource "aws_vpc_endpoint" "ecr_api" {
-  vpc_id              = aws_vpc.igsr5.id
-  service_name        = "com.amazonaws.ap-northeast-1.ecr.api"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = [aws_subnet.igsr5_private_0.id, aws_subnet.igsr5_private_1.id]
-  security_group_ids  = [module.vpc_endpoint_sg.security_group_id]
-  private_dns_enabled = true
-}
+// resource "aws_vpc_endpoint" "s3" {
+//   vpc_id            = aws_vpc.igsr5.id
+//   service_name      = "com.amazonaws.ap-northeast-1.s3"
+//   vpc_endpoint_type = "Gateway"
+// }
+// 
+// resource "aws_vpc_endpoint" "ecr_dkr" {
+//   vpc_id              = aws_vpc.igsr5.id
+//   service_name        = "com.amazonaws.ap-northeast-1.ecr.dkr"
+//   vpc_endpoint_type   = "Interface"
+//   subnet_ids          = [aws_subnet.igsr5_private_0.id, aws_subnet.igsr5_private_1.id]
+//   security_group_ids  = [module.vpc_endpoint_sg.security_group_id]
+//   private_dns_enabled = true
+// }
+// 
+// resource "aws_vpc_endpoint" "ecr_api" {
+//   vpc_id              = aws_vpc.igsr5.id
+//   service_name        = "com.amazonaws.ap-northeast-1.ecr.api"
+//   vpc_endpoint_type   = "Interface"
+//   subnet_ids          = [aws_subnet.igsr5_private_0.id, aws_subnet.igsr5_private_1.id]
+//   security_group_ids  = [module.vpc_endpoint_sg.security_group_id]
+//   private_dns_enabled = true
+// }

--- a/aws/vpc_endpoint_route_table_association.tf
+++ b/aws/vpc_endpoint_route_table_association.tf
@@ -2,7 +2,3 @@
 //   vpc_endpoint_id = aws_vpc_endpoint.s3.id
 //   route_table_id  = aws_route_table.igsr5_private.id
 // }
-resource "aws_vpc_endpoint_route_table_association" "private_s3_0" {
-  vpc_endpoint_id = aws_vpc_endpoint.s3.id
-  route_table_id  = aws_route_table.igsr5_public.id
-}

--- a/aws/vpc_endpoint_route_table_association.tf
+++ b/aws/vpc_endpoint_route_table_association.tf
@@ -1,4 +1,8 @@
+// resource "aws_vpc_endpoint_route_table_association" "private_s3_0" {
+//   vpc_endpoint_id = aws_vpc_endpoint.s3.id
+//   route_table_id  = aws_route_table.igsr5_private.id
+// }
 resource "aws_vpc_endpoint_route_table_association" "private_s3_0" {
   vpc_endpoint_id = aws_vpc_endpoint.s3.id
-  route_table_id  = aws_route_table.igsr5_private.id
+  route_table_id  = aws_route_table.igsr5_public.id
 }


### PR DESCRIPTION
## Why
今月のAWS費用がバカにならなかったため、節約できるところを全力で節約したい。
![Screen Shot 2021-12-31 at 17 21 40](https://user-images.githubusercontent.com/66525257/147812019-e2c285ca-c473-4d3b-b672-27e1a0ee6cd9.png)

画像上から
- Nat Gateway
- ECS Fargate
- VPC Endpoint
- RDS

が幅とってる。RDS はこの前マルチAZやめたら課金止まったのでそれ以外について対応する。

## What
- ECS クラスタをパブリックに移した
  それによって
  - NAT Gateway を止められる
  - VPC Endpoint を消せる

- time management slack のタスク数を2 → 1に変更