### PR TITLE
Add images.igsr5.com resource

### DIFF
--- a/aws/cloudfront.tf
+++ b/aws/cloudfront.tf
@@ -45,3 +45,43 @@ resource "aws_cloudfront_distribution" "igsr5" {
     minimum_protocol_version = "TLSv1"
   }
 }
+
+resource "aws_cloudfront_distribution" "igsr5-images" {
+  origin {
+    domain_name = aws_s3_bucket.igsr5_images.bucket_regional_domain_name
+    origin_id   = "igsr5-images"
+  }
+
+  enabled = true
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "igsr5-images"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = "arn:aws:acm:us-east-1:799705073177:certificate/72fa95c7-b18f-477e-b15b-e7e6fa1658de"
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1"
+  }
+}

--- a/aws/cloudfront.tf
+++ b/aws/cloudfront.tf
@@ -46,7 +46,7 @@ resource "aws_cloudfront_distribution" "igsr5" {
   }
 }
 
-resource "aws_cloudfront_distribution" "igsr5-images" {
+resource "aws_cloudfront_distribution" "igsr5_images" {
   origin {
     domain_name = aws_s3_bucket.igsr5_images.bucket_regional_domain_name
     origin_id   = "igsr5-images"

--- a/aws/ec2.tf
+++ b/aws/ec2.tf
@@ -16,4 +16,7 @@ resource "aws_instance" "igsr5_debug_server" {
   tags = {
     Name = "igsr5-debug"
   }
+  lifecycle {
+    ignore_changes = [ami]
+  }
 }

--- a/aws/route53.tf
+++ b/aws/route53.tf
@@ -32,8 +32,8 @@ resource "aws_route53_record" "igsr5_images" {
   type    = "A"
 
   alias {
-    name    = aws_cloudfront_distribution.igsr5-images.domain_name
-    zone_id = aws_cloudfront_distribution.igsr5-images.hosted_zone_id
+    name    = aws_cloudfront_distribution.igsr5_images.domain_name
+    zone_id = aws_cloudfront_distribution.igsr5_images.hosted_zone_id
 
     evaluate_target_health = true
   }

--- a/aws/route53.tf
+++ b/aws/route53.tf
@@ -26,6 +26,21 @@ resource "aws_route53_record" "igsr5_sandbox_muson" {
   }
 }
 
+resource "aws_route53_record" "igsr5_images" {
+  zone_id = data.aws_route53_zone.igsr5.zone_id
+  name    = format("images.%s", data.aws_route53_zone.igsr5.name)
+  type    = "A"
+
+  alias {
+    name    = aws_cloudfront_distribution.igsr5-images.domain_name
+    zone_id = aws_cloudfront_distribution.igsr5-images.hosted_zone_id
+
+    evaluate_target_health = true
+  }
+}
+
+
+
 resource "aws_route53_record" "igsr5_certificate" {
   name    = tolist(aws_acm_certificate.igsr5.domain_validation_options)[0].resource_record_name
   type    = tolist(aws_acm_certificate.igsr5.domain_validation_options)[0].resource_record_type

--- a/aws/s3.tf
+++ b/aws/s3.tf
@@ -31,3 +31,8 @@ data "aws_iam_policy_document" "alb_log" {
 resource "aws_s3_bucket" "athena" {
   bucket = "athena-igsr5"
 }
+
+resource "aws_s3_bucket" "igsr5_images" {
+  bucket = "igsr5-images"
+  acl    = "private"
+}


### PR DESCRIPTION
## Why

ポートフォリオサイトやその他の個人利用で使える画像サーバがほしい。

## What

- s3 に画像をアップロードし、cloudfront を通して配信する
- ドメイン名は images.igsr5.com にする﻿
