### PR TITLE
Add gmo-practice-ec2

### DIFF
--- a/aws/ec2.tf
+++ b/aws/ec2.tf
@@ -20,3 +20,22 @@ resource "aws_instance" "igsr5_debug_server" {
     ignore_changes = [ami]
   }
 }
+
+resource "aws_key_pair" "igsr5_gmo_practice_server" {
+  key_name   = "igsr5_gmo_practice_server"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCq60lia0S2EnAJfAj3r5y7+QGkXgDLLy4/ECv7d0Akd7t4JaJ49h9o2W3yByKlWJaLsHmocu4xbzk5h+L191los/DSQyUax+n2I1oHlYxyjUVS4OD+Zfi3JHBygcNApIuSvZY0yQR/1mmYHe5m3VCVFnQlVYHr/k45GxXLJR8NNpIABNmIMIhpEpVdlOtpF0nc0GDqBsBOMycwf2ffF7CSBszg7nlOQbgelFhIiielT7IAmFIGVI9JTjNfB49t8AjHefLrkwV16jZ10jkAK2qUQ0gFXJB8lDnow6SQYD+WHlkL26Qgj80e73wADyys4BWkVJYsc/lbX5iOZ/tqYaQGyZFcNIqByiF6At8Q8HjKbKxEt9bl85mYd90E7+c2E+qY5HmKmYqU4/ocIxXyIM6CuhI0oO6Z7kHe0EiZP32EMUWzIPwLB5nsMS+PFNlS3OD6L5fDCVAPfLbWhgH48nFu7nRoY9zzwaoHvqE3MYHy9N/6HC7xN5hJkOyA/lDf2eE= ichigo@Macbook.local"
+}
+
+resource "aws_instance" "igsr5_gmo_practice_server" {
+  ami                    = data.aws_ssm_parameter.amzn2_ami.value
+  instance_type          = "t2.micro"
+  key_name               = aws_key_pair.igsr5_gmo_practice_server.id
+  subnet_id              = aws_subnet.igsr5_public_0.id
+  vpc_security_group_ids = [module.http_sg.security_group_id, module.ssh_sg.security_group_id]
+  tags = {
+    Name = "igsr5-gmo-practice-server"
+  }
+  lifecycle {
+    ignore_changes = [ami]
+  }
+}

--- a/aws/security_group.tf
+++ b/aws/security_group.tf
@@ -14,11 +14,19 @@ module "mysql_sg" {
   cidr_blocks = [aws_vpc.igsr5.cidr_block]
 }
 
-module "nginx_sg" {
+module "http_sg" {
   source      = "./modules/security_group"
-  name        = "nginx-sg"
+  name        = "http-sg"
   vpc_id      = aws_vpc.igsr5.id
   port        = 80
+  cidr_blocks = [aws_vpc.igsr5.cidr_block]
+}
+
+module "ssh_sg" {
+  source      = "./modules/security_group"
+  name        = "ssh-sg"
+  vpc_id      = aws_vpc.igsr5.id
+  port        = 22
   cidr_blocks = [aws_vpc.igsr5.cidr_block]
 }
 


### PR DESCRIPTION
## Why
https://github.com/youngeek-0410/gmo-hackathon-project/issues/2 で使用するデバッグ用のec2 instanceを作成する

## What

```tf
resource "aws_instance" "igsr5_gmo_practice_server" {
  ami                    = data.aws_ssm_parameter.amzn2_ami.value
  instance_type          = "t2.micro"
  key_name               = aws_key_pair.igsr5_gmo_practice_server.id
  subnet_id              = aws_subnet.igsr5_public_0.id
  vpc_security_group_ids = [module.http_sg.security_group_id, module.ssh_sg.security_group_id]
  tags = {
    Name = "igsr5-gmo-practice-server"
  }
  lifecycle {
    ignore_changes = [ami]
  }
}
```